### PR TITLE
Ansible

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,9 @@
+# Ansible
+
+Ansible is a tool for configuration management. If you want to apply the
+configurations in this directory to the fleet, `cd` into this directory and run
+the following.
+
+```
+ansible-playbook -i hosts --ask-become-pass site.yml
+```

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -10,11 +10,11 @@ all:
             nuc7i5b.brooks.network:
     kubernetes:
         children:
-          masters:
+          kubernetes-masters:
             hosts:
               kube-master-a.brooks.network:
               kube-master-b.brooks.network:
-          nodes:
+          kubernetes-nodes:
             hosts:
               kube-node-a1.brooks.network:
               kube-node-a2.brooks.network:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -1,0 +1,10 @@
+all:
+  children:
+    kubernetes:
+      hosts:
+        kube-master-a.brooks.network:
+        kube-master-b.brooks.network:
+        kube-node-a1.brooks.network:
+        kube-node-a2.brooks.network:
+        kube-node-b1.brooks.network:
+        kube-node-b2.brooks.network:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -1,5 +1,10 @@
 all:
   children:
+    bare-metal:
+      hosts:
+        nuc7i5a.brooks.network:
+        nuc7i5b.brooks.network:
+        pi.brooks.network:
     kubernetes:
         children:
           masters:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -2,9 +2,12 @@ all:
   children:
     bare-metal:
       hosts:
-        nuc7i5a.brooks.network:
-        nuc7i5b.brooks.network:
         pi.brooks.network:
+      children:
+        kvm-hosts:
+          hosts:
+            nuc7i5a.brooks.network:
+            nuc7i5b.brooks.network:
     kubernetes:
         children:
           masters:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -1,10 +1,14 @@
 all:
   children:
     kubernetes:
-      hosts:
-        kube-master-a.brooks.network:
-        kube-master-b.brooks.network:
-        kube-node-a1.brooks.network:
-        kube-node-a2.brooks.network:
-        kube-node-b1.brooks.network:
-        kube-node-b2.brooks.network:
+        children:
+          masters:
+            hosts:
+              kube-master-a.brooks.network:
+              kube-master-b.brooks.network:
+          nodes:
+            hosts:
+              kube-node-a1.brooks.network:
+              kube-node-a2.brooks.network:
+              kube-node-b1.brooks.network:
+              kube-node-b2.brooks.network:

--- a/ansible/roles/glusterfs/tasks/main.yml
+++ b/ansible/roles/glusterfs/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install glusterfs-client
+  become: yes
+  apt: name=glusterfs-client state=latest
+
+- name: Enable dm_snapshot kernel module
+  become: yes
+  modprobe:
+    name: dm_snapshot
+    state: present
+
+- name: Enable dm_mirror kernel module
+  become: yes
+  modprobe:
+    name: dm_mirror
+    state: present
+
+- name: Enable dm_thin_pool kernel module
+  become: yes
+  modprobe:
+    name: dm_thin_pool
+    state: present

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,6 @@
+---
+- name: Install GlusterFS
+  hosts: kubernetes-nodes
+
+  roles:
+    - glusterfs


### PR DESCRIPTION
Adds the first iteration of Ansible. As of this pull request, only GlusterFS is under configuration management of Ansible, but this opens the door for:

1. Automating the process of installing [Kubernetes](https://github.com/bswinnerton/blog/blob/gh-pages/_drafts/2017-12-22-creating-a-kubernetes-cluster.md)
2. Defining required packages for the entire fleet (across both Debian and Clear Linux)