### PR TITLE
Add Ansible role for libvirt-guests

### DIFF
--- a/ansible/roles/libvirt-guests/tasks/main.yml
+++ b/ansible/roles/libvirt-guests/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# libvirt-guests is a tool that will auto shut down KVM guests before the host
+# is shut down.
+- name: Enable libvirt-guests
+  become: true
+  systemd:
+    name: libvirt-guests
+    enabled: yes
+    state: started

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -11,6 +11,12 @@
   roles:
     - tallow
 
+- name: Enable libvirt-guests
+  hosts: kvm-hosts
+  tags: kvm
+  roles:
+    - libvirt-guests
+
 - name: Install Docker
   become: true
   hosts: docker-hosts


### PR DESCRIPTION
libvirt-guests is a tool that can ensure that your libvirtd KVM guests are turned off _before_ the underlying host is turned off.

This was enabled by https://github.com/clearlinux/distribution/issues/146.