### PR TITLE
Fix HubZ serial paths for the nyc stick

### DIFF
--- a/nyc/homeassistant/docker-compose.yml
+++ b/nyc/homeassistant/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     privileged: true
     network_mode: host
     devices:
-      - '/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_7150097E-if00-port0:/dev/zwave'
+      - '/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6160005F-if00-port0:/dev/zwave'
     volumes:
       - 'zwave-config:/usr/src/app/store'
 
@@ -55,7 +55,7 @@ services:
     depends_on:
       - mqtt
     devices:
-      - '/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_7150097E-if01-port1:/dev/zigbee'
+      - '/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6160005F-if01-port0:/dev/zigbee'
     volumes:
       - '/etc/localtime:/etc/localtime:ro'
       - 'zigbee2mqtt-data:/app/data'


### PR DESCRIPTION
Deploying #21 on nyc-server failed with:

```
error gathering device information while adding custom device "/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_7150097E-if00-port0": no such file or directory
```

The device paths in `nyc/homeassistant/docker-compose.yml` referenced the HubZ stick with serial `7150097E`, inherited from the repo's pre-reorg config — evidently a different (cabin-era) unit. The stick actually plugged into nyc-server is serial `6160005F`, per `ls -l /dev/serial/by-id/` on the box:

```
usb-Silicon_Labs_HubZ_Smart_Home_Controller_6160005F-if00-port0 -> ../../ttyUSB0   (Z-Wave)
usb-Silicon_Labs_HubZ_Smart_Home_Controller_6160005F-if01-port0 -> ../../ttyUSB1   (Zigbee)
```

Both device mappings are updated. Note the Zigbee interface on this unit enumerates as `if01-port0`, not `if01-port1`. It's still a HubZ, so the `ezsp` adapter at 57600 baud in the Zigbee2MQTT config remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_