### PR TITLE
Remove Z-Wave JS UI from the nyc stack

### DIFF
--- a/nyc/homeassistant/README.md
+++ b/nyc/homeassistant/README.md
@@ -3,17 +3,15 @@
 [Home Assistant](https://www.home-assistant.io/) is the hub for everything smart-home. It runs unprivileged on a bridge network and is served by [Traefik](../traefik/) at `https://home.nyc.brooks.network`. This directory runs it alongside the radios and services it depends on:
 
 - **homeassistant**: Home Assistant itself, exposed on port `8123` behind Traefik.
-- **zwave**: [Z-Wave JS UI](https://github.com/zwave-js/zwave-js-ui), which drives the Z-Wave half of the HubZ (HUSBZB-1) combo stick. It stays host-networked, so its web interface is on port `8091` and the websocket server Home Assistant connects to is on port `3000`.
 - **mqtt**: [Eclipse Mosquitto](https://mosquitto.org/), the MQTT broker that Zigbee2MQTT and Home Assistant communicate through, addressable as `mqtt:1883` from any container on the compose network. It allows anonymous connections since it's only reachable from the home lab network.
-- **zigbee2mqtt**: [Zigbee2MQTT](https://www.zigbee2mqtt.io/), which drives the Zigbee half of the HubZ stick and publishes devices to MQTT with [Home Assistant discovery](https://www.zigbee2mqtt.io/guide/usage/integration/home_assistant.html) enabled, so paired devices show up in Home Assistant automatically. Its frontend is on port `8080`.
+- **zigbee2mqtt**: [Zigbee2MQTT](https://www.zigbee2mqtt.io/), which drives the Zigbee half of the HubZ (HUSBZB-1) combo stick and publishes devices to MQTT with [Home Assistant discovery](https://www.zigbee2mqtt.io/guide/usage/integration/home_assistant.html) enabled, so paired devices show up in Home Assistant automatically. Its frontend is on port `8080`. The stick's Z-Wave radio is unused — there are no Z-Wave devices on this host.
 
 ## Setup
 
 1. Create the shared proxy network if it doesn't exist yet: `sudo docker network create web`.
 2. Bring up [Traefik](../traefik/) first, then this stack with `sudo docker compose up -d`.
 3. In Home Assistant, add the **MQTT** integration (Settings → Devices & Services) pointed at host `mqtt`, port `1883`. No credentials are required.
-4. Point the **Z-Wave JS** integration at `ws://host.docker.internal:3000` — the zwave container is host-networked, so it isn't addressable by service name from the bridge.
-5. Pair Zigbee devices through the Zigbee2MQTT frontend; they'll appear in Home Assistant via MQTT discovery.
+4. Pair Zigbee devices through the Zigbee2MQTT frontend; they'll appear in Home Assistant via MQTT discovery.
 
 ## Things to watch out for
 

--- a/nyc/homeassistant/docker-compose.yml
+++ b/nyc/homeassistant/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - './config/configuration.yaml:/config/configuration.yaml'
       - './config/scenes.yaml:/config/scenes.yaml'
       - './config/scripts.yaml:/config/scripts.yaml'
-    extra_hosts:
-      - 'host.docker.internal:host-gateway'
     expose:
       - 8123
     networks:
@@ -24,19 +22,6 @@ services:
       - 'traefik.http.routers.homeassistant.entrypoints=websecure'
       - 'traefik.http.routers.homeassistant.tls.certresolver=letsencrypt'
       - 'traefik.http.services.homeassistant.loadbalancer.server.port=8123'
-
-  zwave:
-    image: 'zwavejs/zwave-js-ui:latest'
-    container_name: zwave
-    restart: unless-stopped
-    tty: true
-    stop_signal: SIGINT
-    privileged: true
-    network_mode: host
-    devices:
-      - '/dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6160005F-if00-port0:/dev/zwave'
-    volumes:
-      - 'zwave-config:/usr/src/app/store'
 
   mqtt:
     image: 'eclipse-mosquitto:2'
@@ -65,7 +50,6 @@ services:
 
 volumes:
   config:
-  zwave-config:
   mqtt-data:
   zigbee2mqtt-data:
 


### PR DESCRIPTION
There are no Z-Wave devices on the nyc host — the `zwave` service was inherited from the pre-reorg config (nyc had never actually run it: its store volume was freshly created on first `up`, and its logs show a blank store with no port configured). This removes:

- the `zwave` service and its `zwave-config` volume from `nyc/homeassistant/docker-compose.yml`
- the `extra_hosts: host.docker.internal:host-gateway` mapping on the `homeassistant` service, which existed solely so HA could reach the host-networked zwave websocket
- the Z-Wave references in the README (the HubZ stick's Z-Wave radio simply goes unused; its Zigbee half remains Zigbee2MQTT's coordinator)

After merging, `docker compose up -d --remove-orphans` will drop the running `zwave` container, and `docker volume rm homeassistant_zwave-config` cleans up the (empty) store volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_