### PR TITLE
Pin Traefik to v3.6 for Docker Engine 29 compatibility

### DIFF
--- a/cabin/traefik/docker-compose.yml
+++ b/cabin/traefik/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: 'traefik'
+    image: 'traefik:v3.6'
     container_name: traefik
     restart: always
     env_file:

--- a/nyc/traefik/docker-compose.yml
+++ b/nyc/traefik/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: 'traefik'
+    image: 'traefik:v3.6'
     container_name: traefik
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
The nyc Traefik (3.5.3, from the floating `traefik` tag) is failing against the box's Docker Engine 29 daemon:

```
ERR Failed to retrieve information of the docker client and server host error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version" providerName=docker
```

Docker Engine 29 raised the daemon's minimum accepted API version, while Traefik ≤ 3.5 hardcodes API 1.24 as its fallback, so the docker provider can't start and no routes/certs get configured. Traefik 3.6.1+ negotiates the API version with the daemon automatically ([traefik/traefik#12253](https://github.com/traefik/traefik/issues/12253)).

This pins `traefik:v3.6` in both `nyc/traefik/` and `cabin/traefik/` — cabin would hit the identical failure on its next engine update, and pinning a major.minor beats the floating tag for a reverse proxy anyway.

Deploy: `docker compose pull && docker compose up -d` in the traefik directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_