### PR TITLE
Remove migrated http block from Home Assistant config

### DIFF
--- a/nyc/homeassistant/config/configuration.yaml
+++ b/nyc/homeassistant/config/configuration.yaml
@@ -5,8 +5,4 @@ automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml
 
-http:
-  use_x_forwarded_for: true
-  trusted_proxies: 172.16.0.0/12
-
 prometheus:


### PR DESCRIPTION
Home Assistant raised a repair issue after first boot on the new stack:

> The HTTP configuration in `configuration.yaml` has already been migrated and is now being ignored. Please remove the `http:` block from your `configuration.yaml`. This stops working in version 2027.2.0.

The `use_x_forwarded_for` / `trusted_proxies` values were imported into HA's UI-managed storage during onboarding, so the YAML block is dead weight and will become a hard error in 2027.2.0. This removes it.

Note for future rebuilds: if the `config` volume is ever wiped again, the reverse-proxy trust settings won't reseed from YAML anymore — they need to be set once in **Settings → System → Network** after onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_