### PR TITLE
Serve the Zigbee2MQTT frontend through Traefik

### DIFF
--- a/nyc/homeassistant/README.md
+++ b/nyc/homeassistant/README.md
@@ -4,7 +4,7 @@
 
 - **homeassistant**: Home Assistant itself, exposed on port `8123` behind Traefik.
 - **mqtt**: [Eclipse Mosquitto](https://mosquitto.org/), the MQTT broker that Zigbee2MQTT and Home Assistant communicate through, addressable as `mqtt:1883` from any container on the compose network. It allows anonymous connections since it's only reachable from the home lab network.
-- **zigbee2mqtt**: [Zigbee2MQTT](https://www.zigbee2mqtt.io/), which drives the Zigbee half of the HubZ (HUSBZB-1) combo stick and publishes devices to MQTT with [Home Assistant discovery](https://www.zigbee2mqtt.io/guide/usage/integration/home_assistant.html) enabled, so paired devices show up in Home Assistant automatically. Its frontend is on port `8080`. The stick's Z-Wave radio is unused — there are no Z-Wave devices on this host.
+- **zigbee2mqtt**: [Zigbee2MQTT](https://www.zigbee2mqtt.io/), which drives the Zigbee half of the HubZ (HUSBZB-1) combo stick and publishes devices to MQTT with [Home Assistant discovery](https://www.zigbee2mqtt.io/guide/usage/integration/home_assistant.html) enabled, so paired devices show up in Home Assistant automatically. Its frontend is served by Traefik at `https://zigbee.nyc.brooks.network`. The stick's Z-Wave radio is unused — there are no Z-Wave devices on this host.
 
 ## Setup
 

--- a/nyc/homeassistant/docker-compose.yml
+++ b/nyc/homeassistant/docker-compose.yml
@@ -45,8 +45,18 @@ services:
       - '/etc/localtime:/etc/localtime:ro'
       - 'zigbee2mqtt-data:/app/data'
       - './zigbee2mqtt/configuration.yaml:/app/data/configuration.yaml'
-    ports:
-      - '8080:8080'
+    expose:
+      - 8080
+    networks:
+      - web
+      - default
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.docker.network=web'
+      - 'traefik.http.routers.zigbee2mqtt.rule=Host(`zigbee.nyc.brooks.network`)'
+      - 'traefik.http.routers.zigbee2mqtt.entrypoints=websecure'
+      - 'traefik.http.routers.zigbee2mqtt.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080'
 
 volumes:
   config:


### PR DESCRIPTION
Puts the Zigbee2MQTT frontend behind Traefik at `https://zigbee.nyc.brooks.network`, matching how every other web UI on the host is served, instead of publishing plain HTTP on host port `8080`:

- the `zigbee2mqtt` service joins the `web` network (keeping `default` for its `mqtt:1883` connection) and exposes `8080` to Traefik only
- standard router labels: websecure entrypoint, Let's Encrypt cert, service port `8080`
- README updated to point at the new URL

Deploy notes:
- Needs a DNS record for `zigbee.nyc.brooks.network` → the nyc server, like the other names.
- After `docker compose up -d`, the old `8080` host port is no longer published — the frontend is HTTPS-only via Traefik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_