### PR TITLE
Filter HomeKit to lights and climate, minus the office lamps

### DIFF
--- a/nyc/homeassistant/config/configuration.yaml
+++ b/nyc/homeassistant/config/configuration.yaml
@@ -10,8 +10,15 @@ prometheus:
 # HomeKit needs three things to work from a Docker bridge network: the avahi
 # reflector container, port 21063 published on the host, and advertise_ip set
 # to the host's LAN address so iPhones connect to the host rather than the
-# unroutable container IP. Uncomment and fill in the IP, then remove any
-# UI-created HomeKit integration so there's a single bridge.
+# unroutable container IP. Configure HomeKit here rather than in the UI, and
+# keep a single bridge.
 homekit:
   - port: 21063
     advertise_ip: 10.0.90.10
+    filter:
+      include_domains:
+        - light
+        - climate
+      exclude_entities:
+        - light.office_lamp_left
+        - light.office_lamp_right


### PR DESCRIPTION
Adds a `filter:` to the HomeKit bridge so only `light` and `climate` entities are exposed to the Home app, excluding `light.office_lamp_left` and `light.office_lamp_right`.

Deploy: pull and `docker compose restart homeassistant` — paired accessories update in place, no re-pairing needed (iOS may take a minute to drop the removed ones). If the office lamps' entity IDs differ from the assumed slugs, adjust the two `exclude_entities` lines to match what's shown in Settings → Devices & Services → Entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_