### PR TITLE
Drop climate from the HomeKit filter

### DIFF
--- a/nyc/homeassistant/config/configuration.yaml
+++ b/nyc/homeassistant/config/configuration.yaml
@@ -18,7 +18,6 @@ homekit:
     filter:
       include_domains:
         - light
-        - climate
       exclude_entities:
         - light.office_lamp_left
         - light.office_lamp_right


### PR DESCRIPTION
Removes `climate` from the HomeKit bridge's `include_domains`, leaving only `light` (still minus the two office lamps) exposed to the Home app.

Deploy: pull and `docker compose restart homeassistant`; iOS drops the climate accessories shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT62nq9DfJ5JPhZZ5sadNU)_