### PR TITLE
Bridge contact sensors to HomeKit

### DIFF
--- a/nyc/homeassistant/README.md
+++ b/nyc/homeassistant/README.md
@@ -17,6 +17,8 @@ Because Home Assistant runs on a Docker bridge network, its HomeKit mDNS adverti
 
 Configure HomeKit through that YAML block rather than the UI — `advertise_ip` is YAML-only — and pair from the Home app using the QR code in Home Assistant's notifications panel.
 
+The bridge exposes the `light` and `binary_sensor` domains, minus the two office lamps. Including `binary_sensor` wholesale means contact, motion and smoke sensors paired through Zigbee2MQTT show up in the Home app on their own — HomeKit bridges only the [device classes it maps](https://www.home-assistant.io/integrations/homekit/#supported-integrations) (`door`, `window`, `motion`, `smoke`, `moisture` and friends), and the battery and tamper entities Zigbee2MQTT creates alongside them are diagnostic, which HomeKit skips unless a filter names the entity explicitly. To keep a supported sensor out of the Home app, add its entity to `exclude_entities`.
+
 ## Setup
 
 1. Create the shared proxy network if it doesn't exist yet: `sudo docker network create web`.

--- a/nyc/homeassistant/README.md
+++ b/nyc/homeassistant/README.md
@@ -17,7 +17,7 @@ Because Home Assistant runs on a Docker bridge network, its HomeKit mDNS adverti
 
 Configure HomeKit through that YAML block rather than the UI — `advertise_ip` is YAML-only — and pair from the Home app using the QR code in Home Assistant's notifications panel.
 
-The bridge exposes the `light` and `binary_sensor` domains, minus the two office lamps. Including `binary_sensor` wholesale means contact, motion and smoke sensors paired through Zigbee2MQTT show up in the Home app on their own — HomeKit bridges only the [device classes it maps](https://www.home-assistant.io/integrations/homekit/#supported-integrations) (`door`, `window`, `motion`, `smoke`, `moisture` and friends), and the battery and tamper entities Zigbee2MQTT creates alongside them are diagnostic, which HomeKit skips unless a filter names the entity explicitly. To keep a supported sensor out of the Home app, add its entity to `exclude_entities`.
+The filter is deliberately narrow. Contact sensors are matched by the `binary_sensor.*_contact` glob rather than by including the whole `binary_sensor` domain, because HomeKit falls back to advertising an occupancy sensor for any device class it doesn't map — so a domain-wide include turns the `tamper` entity Zigbee2MQTT pairs alongside a contact sensor into a phantom motion sensor in the Home app. Zigbee2MQTT names a contact sensor's entity `binary_sensor.<device>_contact`, so the glob catches new door and window sensors as they're paired; a sensor renamed in Home Assistant needs its entity listed explicitly.
 
 ## Setup
 

--- a/nyc/homeassistant/config/configuration.yaml
+++ b/nyc/homeassistant/config/configuration.yaml
@@ -16,15 +16,10 @@ homekit:
   - port: 21063
     advertise_ip: 10.0.90.10
     filter:
-      # binary_sensor is included as a whole domain so contact, motion and
-      # smoke sensors paired through Zigbee2MQTT are bridged without listing
-      # each entity here. HomeKit only maps the device classes it understands
-      # (door, window, motion, smoke, moisture, etc.), and the per-device
-      # battery and tamper entities Zigbee2MQTT creates are diagnostic, which
-      # HomeKit skips unless a filter names them explicitly.
       include_domains:
         - light
-        - binary_sensor
+      include_entity_globs:
+        - binary_sensor.*_contact
       exclude_entities:
         - light.office_lamp_left
         - light.office_lamp_right

--- a/nyc/homeassistant/config/configuration.yaml
+++ b/nyc/homeassistant/config/configuration.yaml
@@ -16,8 +16,15 @@ homekit:
   - port: 21063
     advertise_ip: 10.0.90.10
     filter:
+      # binary_sensor is included as a whole domain so contact, motion and
+      # smoke sensors paired through Zigbee2MQTT are bridged without listing
+      # each entity here. HomeKit only maps the device classes it understands
+      # (door, window, motion, smoke, moisture, etc.), and the per-device
+      # battery and tamper entities Zigbee2MQTT creates are diagnostic, which
+      # HomeKit skips unless a filter names them explicitly.
       include_domains:
         - light
+        - binary_sensor
       exclude_entities:
         - light.office_lamp_left
         - light.office_lamp_right


### PR DESCRIPTION
The HomeKit bridge's filter only included the `light` domain, so the newly paired door sensor never reached the Home app. This adds a `binary_sensor.*_contact` glob to the filter in `nyc/homeassistant/config/configuration.yaml`.

### Why a glob rather than the domain or a named entity

The door sensor arrives through Zigbee2MQTT's MQTT discovery, so its entity ID isn't checked in anywhere. Zigbee2MQTT names a contact expose's entity `binary_sensor.<device>_contact`, and that entity carries `device_class: door`, which HomeKit maps to a contact sensor accessory. The glob catches it, plus future door and window sensors, without hardcoding a name that only exists at runtime.

Including the whole `binary_sensor` domain would have been wrong. HomeKit doesn't ignore device classes it can't map — it falls back to advertising them as occupancy sensors. The `tamper` entity Zigbee2MQTT pairs alongside every contact sensor isn't marked diagnostic, so a domain-wide include would have put a phantom motion sensor in the Home app for each door sensor.

### Notes

- The `light` includes and the two office lamp exclusions are unchanged.
- The README's HomeKit section documents the glob and the occupancy fallback it avoids.
- Verified the YAML parses; the filter resolves to `include_domains: [light]`, `include_entity_globs: [binary_sensor.*_contact]`, and the same two exclusions.
- A sensor renamed in Home Assistant so its entity no longer ends in `_contact` needs to be listed explicitly.
- Requires a Home Assistant restart to take effect — the new accessory joins the existing bridge, so no re-pairing.